### PR TITLE
レーン幅が動的に調節されることによりデッドロック状態になった際への対処

### DIFF
--- a/crowdwalk/src/main/resources/fallbackParameters.json
+++ b/crowdwalk/src/main/resources/fallbackParameters.json
@@ -18,7 +18,7 @@
         "trail" : 100.0,
         "trailCountStep" : 1.0,
         "rule" : [],
-        "disableNextLinkCache" : false,
+        "accelerationOfRecoveringHeadAgent" : 0.0,
         "_" : null
     },
     "generation" : {

--- a/crowdwalk/src/main/resources/fallbackParameters.json
+++ b/crowdwalk/src/main/resources/fallbackParameters.json
@@ -18,6 +18,7 @@
         "trail" : 100.0,
         "trailCountStep" : 1.0,
         "rule" : [],
+        "disableNextLinkCache" : false,
         "_" : null
     },
     "generation" : {


### PR DESCRIPTION
レーン幅が動的に調節されるようになっているが，この弊害により全体が行ったり来たりを繰り返すと対抗流と力がバランスしてしまい動けなくなることがある．
これに対して，完全に止まってしまった際はリンク先頭のエージェントに微量の加速度を与えることができるようにした．
（力に逆らって無理やり動くことを試みること自体は，エージェントの挙動として自然であると考える）
デフォルトの設定では，agent.accelerationOfRecoveringHeadAgent=0.0 であり，これまでの挙動は変化しない．