### PR TITLE
For AppleSilicon mac javajxplugin is updated to 0.0.11

### DIFF
--- a/crowdwalk/build.gradle
+++ b/crowdwalk/build.gradle
@@ -11,7 +11,7 @@ plugins {
     id 'application'
     id "com.google.osdetector" version "1.7.0"
     /* JavaFXのプラグインはここでは適用せず，後の分岐で適用する */
-    id 'org.openjfx.javafxplugin' version '0.0.10' apply false
+    id 'org.openjfx.javafxplugin' version '0.0.11' apply false
 }
 
 apply plugin: 'com.google.osdetector'


### PR DESCRIPTION
# AppleSilicon mac can run the sample in gui mode

## Environment
### machine
- CPU: Apple M1 Max
- Mem: 64GB
- OS: MacOS Sequia 15.3
### java version
```
openjdk 17.0.14 2025-01-21 LTS
OpenJDK Runtime Environment Microsoft-10800294 (build 17.0.14+7-LTS)
OpenJDK 64-Bit Server VM Microsoft-10800294 (build 17.0.14+7-LTS, mixed mode, sharing)
```
### gradle version
```
------------------------------------------------------------
Gradle 8.2.1
------------------------------------------------------------

Build time:   2023-07-10 12:12:35 UTC
Revision:     a38ec64d3c4612da9083cc506a1ccb212afeecaa

Kotlin:       1.8.20
Groovy:       3.0.17
Ant:          Apache Ant(TM) version 1.10.13 compiled on January 4 2023
JVM:          17.0.14 (Microsoft 17.0.14+7-LTS)
OS:           Mac OS X 15.3 aarch64
```

## Problem
- installation is seemed good
    - the following lines are the terminal print when running `./gradlew` in CorwdWalk/crowdwalk dir.
```
$ LANG=ja_JP.UTF-8 JAVA_OPTS='-Dgroovy.source.encoding=UTF-8 -Dfile.encoding=UTF-8' ./gradlew
...
BUILD SUCCESSFUL in 20s
9 actionable tasks: 8 executed, 1 up-to-date
```
- however, an error occers when running sample
- the following lines are the part of errors
```
$ LANG=ja_JP.UTF-8 JAVA_OPTS='-Dgroovy.source.encoding=UTF-8 -Dfile.encoding=UTF-8' sh quickstart.sh sample/basic-sample/properties.json -g
...
ITK_Info[Map Check]:all goals can be reachable from whole map.
2月 28, 2025 5:22:03 午後 com.sun.javafx.application.PlatformImpl startup
警告: Unsupported JavaFX configuration: classes were loaded from 'unnamed module @36891ac9'
Loading library prism_es2 from resource failed: java.lang.UnsatisfiedLinkError: /Users/take/.openjfx/cache/17/libprism_es2.dylib: dlopen(/Users/take/.openjfx/cache/17/libprism_es2.dylib, 0x0001): tried: '/Users/take/.openjfx/cache/17/libprism_es2.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/take/.openjfx/cache/17/libprism_es2.dylib' (no such file), '/Users/take/.openjfx/cache/17/libprism_es2.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
java.lang.UnsatisfiedLinkError: /Users/take/.openjfx/cache/17/libprism_es2.dylib: dlopen(/Users/take/.openjfx/cache/17/libprism_es2.dylib, 0x0001): tried: '/Users/take/.openjfx/cache/17/libprism_es2.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/take/.openjfx/cache/17/libprism_es2.dylib' (no such file), '/Users/take/.openjfx/cache/17/libprism_es2.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
...
Loading library prism_sw from resource failed: java.lang.UnsatisfiedLinkError: /Users/take/.openjfx/cache/17/libprism_sw.dylib: dlopen(/Users/take/.openjfx/cache/17/libprism_sw.dylib, 0x0001): tried: '/Users/take/.openjfx/cache/17/libprism_sw.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/take/.openjfx/cache/17/libprism_sw.dylib' (no such file), '/Users/take/.openjfx/cache/17/libprism_sw.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
java.lang.UnsatisfiedLinkError: /Users/take/.openjfx/cache/17/libprism_sw.dylib: dlopen(/Users/take/.openjfx/cache/17/libprism_sw.dylib, 0x0001): tried: '/Users/take/.openjfx/cache/17/libprism_sw.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64')), '/System/Volumes/Preboot/Cryptexes/OS/Users/take/.openjfx/cache/17/libprism_sw.dylib' (no such file), '/Users/take/.openjfx/cache/17/libprism_sw.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e' or 'arm64'))
...
Graphics Device initialization failed for :  es2, sw
Error initializing QuantumRenderer: no suitable pipeline found
java.lang.RuntimeException: java.lang.RuntimeException: Error initializing QuantumRenderer: no suitable pipeline found
...
```

## How to fix it
- In github openjfx/javafx-gradle-plugin repository, the issue 112 can solve the problem
    - https://github.com/openjfx/javafx-gradle-plugin/issues/112
    - TL;DR: changing the version of javafx-gradle-plugin from 0.0.10 to 0.0.11 or above

## Result
- it works well :)